### PR TITLE
Fix cognitive test utilities

### DIFF
--- a/src/tests/cognitive/LongTermQualityMonitor.ts
+++ b/src/tests/cognitive/LongTermQualityMonitor.ts
@@ -1,4 +1,4 @@
-import { CognitiveQualityTest } from "./CognitiveQualityTest";
+import { CognitiveQualityTest, CognitiveMetrics } from "./CognitiveQualityTest";
 import { SimulationRuntime } from "../../runtime/SimulationRuntime";
 
 export class LongTermQualityMonitor {

--- a/src/tests/cognitive/evaluators/CognitiveEvaluator.ts
+++ b/src/tests/cognitive/evaluators/CognitiveEvaluator.ts
@@ -1,1 +1,25 @@
- 
+import { SimulationRuntime } from "../../../runtime/SimulationRuntime";
+
+export class CognitiveEvaluator {
+  constructor(private runtime: SimulationRuntime, private agent: number) {}
+
+  evaluateCoherence(_responses: string[]): number {
+    return 1;
+  }
+
+  evaluateContextualRelevance(_response: string, _context: string): number {
+    return 1;
+  }
+
+  evaluateCreativity(_solution: string): number {
+    return 1;
+  }
+
+  evaluateMemoryAccuracy(recall: string, original: string): number {
+    return recall.includes(original) ? 1 : 0;
+  }
+
+  evaluateGoalAlignment(): number {
+    return 1;
+  }
+}


### PR DESCRIPTION
## Summary
- export `CognitiveMetrics`
- add goal-alignment helper
- provide dummy CognitiveEvaluator implementation
- update LongTermQualityMonitor to import the metrics interface
- allow CognitiveQualityTest to run even if runtime doesn't implement stimulus helpers

## Testing
- `npx tsc -b --pretty false` *(fails: Cannot find module '../utils/testSetup')*

------
https://chatgpt.com/codex/tasks/task_e_6843cea5fa50832488c53ed6863d7150