### PR TITLE
Add discord monitoring flow docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,11 @@ The project includes several example scenarios:
 
 - `basic-conversation.ts`: Two agents engaging in basic interaction
 
+## Discord Monitoring Flow
+
+ArgOS can connect to a Discord channel and generate automated summaries.
+See `docs/DISCORD_REPORT_FLOW.md` for a step-by-step outline.
+
 ## Contributing
 
 This is an experimental project in active development. Feel free to explore and experiment with the codebase.

--- a/docs/DISCORD_REPORT_FLOW.md
+++ b/docs/DISCORD_REPORT_FLOW.md
@@ -1,0 +1,70 @@
+# Discord Monitoring and Reporting Flow
+
+This document outlines how ArgOS agents can monitor a Discord channel, summarize the discussion, and push the summary to a separate Git repository.
+
+## Overview
+
+1. **Discord Integration**
+   - Use a Discord bot to listen to messages in the target channel.
+   - Convert each new message into a stimulus that can be processed by the agent system.
+
+2. **Agent Processing**
+   - Agents treat the Discord channel as a `Room` of type `"discord"`.
+   - Received stimuli are fed through the usual perception and cognition systems.
+   - A dedicated reporting agent compiles key points from the channel activity.
+
+3. **Summary Generation**
+   - Periodically (e.g., once per day) the reporting agent produces a concise summary.
+   - The summary is written to a markdown file.
+
+4. **Commit to External Repository**
+   - Use a Git client library or CLI to commit the summary file to a separate repository.
+   - Push the commit with a message indicating the date and channel.
+
+## Implementation Steps
+
+1. **Create a Discord Bot**
+   - Register a new bot on the Discord developer portal.
+   - Invite the bot to the channel with permission to read messages.
+   - Store the bot token in `.env` and load it in your integration code.
+
+2. **Add a Discord Integration Service**
+   - Build a small Node service that listens for Discord events and injects stimuli into the ArgOS `Room` representing the channel.
+   - Each message should include the author and timestamp so agents can track context.
+
+3. **Design the Reporting Agent**
+   - Implement an agent with access to the Discord room's stimuli history.
+   - After a configurable time span, compile important messages or topics.
+   - Use the system's language model integration to produce a short summary.
+
+4. **Write the Summary to a Git Repo**
+   - Create or clone the target repository locally.
+   - When the summary is generated, write it to a new markdown file (e.g., `reports/YYYY-MM-DD.md`).
+   - Commit and push the file using Node's `child_process` to invoke `git` or a Git library.
+
+5. **Scheduling**
+   - Use `cron` or a job scheduler to trigger summary generation and git commits at regular intervals.
+
+## Example Folder Structure
+
+```
+|-- integrations/
+|   `-- discordBot.ts       # Handles Discord events and message forwarding
+|-- agents/
+|   `-- reportingAgent.ts   # Aggregates stimuli and creates summaries
+|-- scripts/
+|   `-- pushSummary.ts      # Commits and pushes the summary
+```
+
+## Security Considerations
+
+- Keep Discord tokens and Git credentials secure in environment variables.
+- Consider rate limits and message volume when processing Discord events.
+- Ensure the reporting agent respects privacy expectations for the channel.
+
+## Next Steps
+
+- Prototype the Discord bot and confirm messages can be received.
+- Connect the bot's messages to the ArgOS stimulus system.
+- Implement the reporting agent logic and automate the Git commit pipeline.
+


### PR DESCRIPTION
## Summary
- add new doc describing how ArgOS agents can monitor a Discord channel and write summaries to a git repo
- mention Discord monitoring flow in README

## Testing
- `npm install`
- `npm test` *(fails: Jest couldn't parse TS files)*

------
https://chatgpt.com/codex/tasks/task_e_6843d2a70558832492002978590bb8e5