### PR TITLE
Update README with server build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,12 @@ The project includes several example scenarios:
 
 - `basic-conversation.ts`: Two agents engaging in basic interaction
 
+## Running the Server and Client
+
+- **Server only**: Use `npm run dev:server` to start just the WebSocket server. It listens on port `3000` by default as defined in `src/server/index.ts`.
+- **Build the client**: Run `npm run build` to compile the React client. The build output is generated in `dist/client`.
+- **Serve the build**: After building, you can serve the static files with any HTTP server (e.g. `npx vite preview` or `npx serve ./dist/client`).
+
 ## Discord Monitoring Flow
 
 ArgOS can connect to a Discord channel and generate automated summaries.


### PR DESCRIPTION
## Summary
- document server-only run command and client build process in README

## Testing
- `npm test` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_6843d76819788324b609602c6247c644